### PR TITLE
Add tests

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -6,7 +6,7 @@ export interface Channel {
     onData: (cb: OnMessageCallback) => void
     onConnect: (cb: () => void) => void
     onDisconnect: (cb: () => void) => void
-    onError?: (e: Error) => void
+    onError: (cb: (e: Error) => void) => void
 }
 
 export abstract class GenericChannel implements Channel {
@@ -16,8 +16,8 @@ export abstract class GenericChannel implements Channel {
     private _onMessageCallbacks: OnMessageCallback[] = []
     private _onConnectCallbacks: Function[] = []
     private _onDisconnectCallbacks: Function[] = []
+    private _onErrorCallbacks: Function[] = []
     private _ready = false
-    public onError: (e: Error) => void
     public abstract send(message: {}): void
 
     public onData(cb: OnMessageCallback): void {
@@ -37,14 +37,16 @@ export abstract class GenericChannel implements Channel {
         this._onDisconnectCallbacks.push(cb)
     }
 
+    public onError(cb: Function): void {
+        this._onErrorCallbacks.push(cb)
+    }
+
     protected _messageReceived(message: {}) {
         this._onMessageCallbacks.forEach(cb => cb(message))
     }
 
     protected _error(error: any) {
-        if (this.onError) {
-            this.onError(error)
-        }
+        this._onErrorCallbacks.forEach(cb => cb(error))
     }
 
     protected _connected() {

--- a/src/Slot.ts
+++ b/src/Slot.ts
@@ -34,17 +34,17 @@ export function slot<RequestData=void, ResponseData=void>(): Slot<RequestData, R
     return FAKE_SLOT
 }
 
-export function connectSlot<T=void>(slotName: string, transports: Transport[]): Slot<T> {
+export function connectSlot<T=void, T2=void>(slotName: string, transports: Transport[]): Slot<T, T2> {
 
     // These will be all the handlers for this slot (eg. all the callbacks registered with `Slot.on()`)
     const handlers = [] as Handler<any, any>[]
 
     // For each transport we create a Promise that will be fulfilled only
     // when the far-end has registered a handler.
-    // This prevents `triggers` from firing *before* any far-end is listeninng.
+    // This prevents `triggers` from firing *before* any far-end is listening.
     let remoteHandlersConnected = [] as Promise<any>[]
 
-    // Signal to the transport that we will accept handlers for this slotName
+    // Signal to all transports that we will accept handlers for this slotName
     transports.forEach(t => {
 
         // Variable holds the promise's `resolve` function. A little hack
@@ -110,5 +110,5 @@ export function connectSlot<T=void>(slotName: string, transports: Transport[]): 
 
     }
 
-    return trigger as Slot<T>
+    return trigger as Slot<T, T2>
 }

--- a/test/Channel.test.ts
+++ b/test/Channel.test.ts
@@ -1,0 +1,40 @@
+import 'should'
+
+import { TestChannel } from './TestChannel'
+import * as sinon from 'sinon'
+
+describe('GenericChannel', () => {
+
+    it('should call onConnect subscribers when its _connected method is called', () => {
+        const testInstance = new TestChannel()
+        const spy = sinon.spy()
+        testInstance.onConnect(spy)
+        testInstance.callConnected()
+        spy.called.should.be.True()
+    })
+
+    it('should call onDisconnect subscribers when its _disconnected method is called', () => {
+        const testInstance = new TestChannel()
+        const spy = sinon.spy()
+        testInstance.onDisconnect(spy)
+        testInstance.callDisconnected()
+        spy.called.should.be.True()
+    })
+
+    it('should call onData callbacks when its _messageReceived method is called', () => {
+        const testInstance = new TestChannel()
+        const spy = sinon.spy()
+        testInstance.onData(spy)
+        testInstance.callMessageReceived()
+        spy.called.should.be.True()
+    })
+
+    it('should call onError callbacks when its _error method is called', () => {
+        const testInstance = new TestChannel()
+        const spy = sinon.spy()
+        testInstance.onError(spy)
+        testInstance.callError()
+        spy.called.should.be.True()
+    })
+
+})

--- a/test/Event.test.ts
+++ b/test/Event.test.ts
@@ -1,0 +1,93 @@
+import 'should'
+
+import {slot} from './../src/Slot'
+import {combineEvents, createEventBus} from './../src/Events'
+import {GenericChannel} from './../src/Channel'
+import {TransportMessage} from './../src/Transport'
+import {TestChannel} from './TestChannel'
+import * as sinon from 'sinon'
+
+describe('combineEvents()', () => {
+
+    it('should correctly combine several EventDeclarations', () => {
+        const combined = combineEvents(
+            {
+                hello: slot<{ name: string }>()
+            },
+            {
+                how: slot<{ mode: 'simple' | 'advanced'}>(),
+                are: slot<{ tense: number }>()
+            },
+            {
+                you: slot<{ reflective: boolean }>()
+            }
+        )
+        Object.keys(combined).should.eql(['hello', 'how', 'are', 'you'])
+
+        // Uncomment the following to check that combineEvents
+        // does preserve each slot's typings: they contain type errors
+        // combined.hello({ name: 5 })
+        // combined.how({ mode: 'smiple' })
+        // combined.are({ tense: true })
+        // combined.you({ reflective: 5 })
+    })
+
+})
+
+describe('createEventBus()', () => {
+
+    const events = {
+        numberToString: slot<number, string>()
+    }
+
+    it('should correctly create an event bus with no channels', async () => {
+
+        // Attempting to use the events without having
+        // created an event bus fails
+        const bad = () => events.numberToString(5)
+        bad.should.throw(/Slot not connected/)
+
+        // After creating an event bus, events can be
+        // subscribed to and triggered
+        const eventBus = createEventBus({ events })
+        eventBus.numberToString.on(num => num.toString())
+        const res = await eventBus.numberToString(5)
+        res.should.eql('5')
+    })
+
+    it('should connect the channels passed as argument', async () => {
+
+        const channel = new TestChannel()
+        const eventBus = createEventBus({
+            events,
+            channels: [ channel ]
+        })
+        channel.callConnected()
+
+        // When a handler is added locally, a message should be
+        // sent through the Channel to signal the registration
+        eventBus.numberToString.on(num => num.toString())
+        channel.sendSpy.calledWith({
+            type: 'handler_registered',
+            slotName: 'numberToString'
+        }).should.be.True()
+
+        // When a request is sent from the Channel, it should
+        // be treated and a message sent in response
+        channel.fakeReceive({
+            type: 'request',
+            slotName: 'numberToString',
+            id: '0',
+            data: 5
+        })
+
+        await Promise.resolve() // yied to ts-event-bus internals
+        channel.sendSpy.calledWith({
+            type: 'response',
+            slotName: 'numberToString',
+            id: '0',
+            data: '5'
+        }).should.be.True()
+    })
+
+})

--- a/test/Handler.test.ts
+++ b/test/Handler.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon'
 import { callHandlers } from '../src/Handler'
 
 describe('callHandlers()', () => {
+
     context('with no handler', () => {
         it('should return a Promise', () => {
             const result = callHandlers('my-data', [])
@@ -12,78 +13,73 @@ describe('callHandlers()', () => {
     })
 
     context('with one handler', () => {
-        it('should call this handler with the given data', (done) => {
+
+        it('should call this handler with the given data', () => {
             const handlerSpy = sinon.spy()
             const data = 'my-data'
-            const result = callHandlers(data, [handlerSpy])
+            return callHandlers(data, [handlerSpy])
                 .then(() => {
                     sinon.assert.calledOnce(handlerSpy)
                     sinon.assert.calledWith(handlerSpy, data)
-                    done()
                 })
-                .catch(err => { throw new Error(err) })
         })
 
         context('which throw an error', () => {
-            it('should return a rejected promise', (done) => {
+
+            it('should return a rejected promise', () => {
                 const error = new Error('fail')
                 const handlerStub = () => {
                     throw error
                 }
-
-                callHandlers('my-data', [handlerStub])
+                return callHandlers('my-data', [handlerStub])
                     .catch(err => {
                         err.should.equal(error)
-                        done()
                     })
             })
         })
 
-        context('which return a Promise', () => {
-            it('should return it', (done) => {
+        context('which returns a Promise', () => {
+
+            it('should return it', () => {
                 const promise = new Promise((resolve) => { resolve('toto') })
                 const handlerStub = sinon.stub().returns(promise)
 
                 const result = callHandlers('my-data', [handlerStub])
                 result.should.equal(promise)
-                result.then(res => {
+                return result.then(res => {
                     res.should.equal('toto')
-                    done()
                 })
             })
+
         })
 
         context('which doesnt return a Promise', () => {
-            it('should return a fullfilled promise with the result', (done) => {
+            it('should return a fullfilled promise with the result', () => {
                 const data = 'result'
                 const handlerStub = sinon.stub().returns(data)
 
                 const result = callHandlers('my-data', [handlerStub])
                 result.should.have.property('then').which.is.a.Function()
 
-                result
+                return result
                     .then(res => {
                         res.should.equal(data)
-                        done()
                     })
-                    .catch(err => { throw new Error(err) })
             })
         })
     })
 
     context('with multiple handlers', () => {
-        it('should call all of them with the same given data', (done) => {
+        it('should call all of them with the same given data', () => {
             const handlerSpies = [sinon.spy(), sinon.spy()]
             const data = 'my-data'
-            const result = callHandlers(data, handlerSpies)
+            return callHandlers(data, handlerSpies)
                 .then(() => {
                     sinon.assert.calledOnce(handlerSpies[0])
                     sinon.assert.calledOnce(handlerSpies[1])
                     sinon.assert.calledWith(handlerSpies[0], data)
                     sinon.assert.calledWith(handlerSpies[1], data)
-                    done()
                 })
-                .catch(err => { throw new Error(err) })
         })
     })
 })

--- a/test/Handler.test.ts
+++ b/test/Handler.test.ts
@@ -70,16 +70,14 @@ describe('callHandlers()', () => {
     })
 
     context('with multiple handlers', () => {
-        it('should call all of them with the same given data', () => {
+        it('should call all of them with the same given data', async () => {
             const handlerSpies = [sinon.spy(), sinon.spy()]
             const data = 'my-data'
-            return callHandlers(data, handlerSpies)
-                .then(() => {
-                    sinon.assert.calledOnce(handlerSpies[0])
-                    sinon.assert.calledOnce(handlerSpies[1])
-                    sinon.assert.calledWith(handlerSpies[0], data)
-                    sinon.assert.calledWith(handlerSpies[1], data)
-                })
+            await callHandlers(data, handlerSpies)
+            sinon.assert.calledOnce(handlerSpies[0])
+            sinon.assert.calledOnce(handlerSpies[1])
+            sinon.assert.calledWith(handlerSpies[0], data)
+            sinon.assert.calledWith(handlerSpies[1], data)
         })
     })
 })

--- a/test/Slot.test.ts
+++ b/test/Slot.test.ts
@@ -1,0 +1,117 @@
+import 'should'
+
+import { connectSlot } from './../src/Slot'
+import { TestChannel } from './TestChannel'
+import { Transport } from './../src/Transport'
+
+const makeTestTransport = () => {
+    const channel = new TestChannel()
+    const transport = new Transport(channel)
+    channel.callConnected()
+    return { channel, transport }
+}
+
+describe('connectSlot()', () => {
+
+    context('with no transports', () => {
+
+        it('should call the local handler if there is only one', () => {
+            const numberToString = connectSlot<number, string>('numberToString', [])
+            numberToString.on(num => num.toString())
+            return numberToString(56)
+                .then(res => res.should.eql('56'))
+        })
+
+        it('should call all handlers if there is more than one', async () => {
+            const broadcastBool = connectSlot<boolean>('broadcastBool', [])
+            const results: string[] = []
+            broadcastBool.on(b => {
+                results.push(`1:${b}`)
+            })
+            broadcastBool.on(b => {
+                results.push(`2:${b}`)
+            })
+            broadcastBool.on(b => {
+                results.push(`3:${b}`)
+            })
+            await broadcastBool(true)
+            results.should.eql([
+                '1:true',
+                '2:true',
+                '3:true'
+            ])
+        })
+
+        it('should allow to unregister handlers', async () => {
+            const broadcastNumber = connectSlot<number>('broadcastNumber', [])
+            let results: number[] = []
+            const runTest = (n: number) => {
+                results = []
+                return broadcastNumber(n)
+            }
+
+            // Add two handlers and save references to
+            // the unsub function of the second
+            broadcastNumber.on(n => {
+                results.push(n - 1)
+            })
+            const unreg = broadcastNumber.on(n => {
+                results.push(n - 2)
+            })
+
+            // Trigger the event once
+            await runTest(5)
+
+            // both handlers should have been called
+            results.should.eql([4, 3])
+
+            // unregister the second handler, then trigger
+            // the event a second time: only the second handler
+            // should be called
+            unreg()
+            await runTest(56)
+            results.should.eql([55])
+        })
+
+    })
+
+    context('with local and remote handlers', () => {
+
+        it('should call both local handlers and remote handlers', async () => {
+            const {channel, transport} = makeTestTransport()
+            const broadcastBool = connectSlot<boolean>('broadcastBool', [transport])
+            let localCalled = false
+            broadcastBool.on(b => { localCalled = true })
+            const triggerPromise = broadcastBool(true)
+
+            // Handlers should not be called until a remote handler is registered
+            await Promise.resolve()
+            localCalled.should.be.False()
+            channel.fakeReceive({ type: 'handler_registered', slotName: 'broadcastBool'})
+
+            // setTimeout(0) to yield control to ts-event-bus internals,
+            // so that the call to handlers can be processed
+            await new Promise(resolve => setTimeout(resolve, 0))
+
+            // Once a remote handler is registered, both local and remote should be called
+            localCalled.should.be.True()
+            const request = channel.sendSpy.lastCall.args[0]
+            request.should.match({
+                type: 'request',
+                slotName: 'broadcastBool',
+                data: true
+            })
+
+            // triggerPromise should resolve once a remote response is received
+            channel.fakeReceive({
+                type: 'response',
+                id: request.id,
+                slotName: 'broadcastBool',
+                data: null
+            })
+            await triggerPromise
+        })
+
+    })
+
+})

--- a/test/TestChannel.ts
+++ b/test/TestChannel.ts
@@ -1,0 +1,44 @@
+import {GenericChannel} from './../src/Channel'
+import {TransportMessage} from './../src/Transport'
+import * as sinon from 'sinon'
+
+export class TestChannel extends GenericChannel {
+
+    public sendSpy = sinon.spy()
+
+    constructor(public timeout?: number) {
+        super()
+    }
+
+    /**
+     * Allows to inspect calls to Channel.send() by a transport
+     */
+
+    public callConnected() {
+        this._connected()
+    }
+
+    public callDisconnected() {
+        this._disconnected()
+    }
+
+    public callMessageReceived()  {
+        this._messageReceived({ type: 'test' })
+    }
+
+    public callError() {
+        this._error(new Error('LOLOL'))
+    }
+
+    public send(message: TransportMessage) {
+        this.sendSpy(message)
+    }
+
+    /**
+     * Allows to fake reception of messages from the far end
+     */
+    public fakeReceive(message: TransportMessage) {
+        this._messageReceived(message)
+    }
+
+}

--- a/test/Transport.test.ts
+++ b/test/Transport.test.ts
@@ -1,0 +1,128 @@
+import 'should'
+
+import { Transport, TransportMessage } from './../src/Transport'
+import { TestChannel } from './TestChannel'
+import * as sinon from 'sinon'
+import { createEventBus } from '../src/Events'
+import { slot } from '../src/Slot'
+
+describe('Transport', () => {
+
+    context('subscriptions', () => {
+
+        const channel = new TestChannel()
+        const stubMethods: Array<keyof TestChannel> = ['onConnect', 'onDisconnect', 'onData', 'onError']
+        stubMethods.forEach(method => sinon.stub(channel, method))
+        const transport = new Transport(channel)
+
+        stubMethods.forEach(methodName => it(`should subscribe to its channel\'s ${methodName} method`, () => {
+            const method = channel[methodName] as any as sinon.SinonSpy
+            method.called.should.be.True()
+            method.restore()
+        }))
+
+    })
+
+    context('handler registration and requests', () => {
+
+        const channel = new TestChannel()
+        const transport = new Transport(channel)
+        const handlers = {
+            buildCelery: sinon.spy(() => ({ color: 'blue' })),
+            getCarrotStock: sinon.spy()
+        }
+
+        it('should send a handler_registered message when a local handler is registered', () => {
+            channel.callConnected()
+            Object.keys(handlers).forEach(slotName => {
+                transport.registerHandler(slotName, handlers[slotName])
+                channel.sendSpy.calledWith({
+                    type: 'handler_registered',
+                    slotName
+                }).should.be.True()
+            })
+        })
+
+        it('should call the appropriate handler when a request is received', async () => {
+            const slotName = 'buildCelery'
+            const handler = handlers[slotName]
+            handler.called.should.be.False()
+            const request: TransportMessage = {
+                type: 'request',
+                slotName,
+                id: '5',
+                data: {
+                    height: 5,
+                    constitution: 'strong'
+                }
+            }
+            channel.fakeReceive(request)
+
+            await Promise.resolve() // yield to ts-event-bus internals
+            handler.calledWith(request.data).should.be.True()
+            channel.sendSpy.lastCall.args[0].should.eql({
+                slotName,
+                type: 'response',
+                id: '5',
+                data: {
+                    color: 'blue'
+                }
+            })
+        })
+
+        context('adding and using a remote handler', () => {
+
+            const slotName = 'getCarrotStock'
+            const addLocalHandler = sinon.spy()
+            let localHandler: (...args: any[]) => Promise<any>
+
+            it('should add a local handler when a remote handler registration is received', () => {
+                transport.onRemoteHandlerRegistered(slotName, addLocalHandler)
+                channel.fakeReceive({
+                    type: 'handler_registered',
+                    slotName
+                })
+                addLocalHandler.called.should.be.True()
+                localHandler = addLocalHandler.lastCall.args[0]
+            })
+
+            it('should resolve a local pending request when a response is received', () => {
+                const requestData = { carrotType: 'red' }
+                const pendingPromise = localHandler(requestData)
+                const request = channel.sendSpy.lastCall.args[0]
+                request.should.match({
+                    type: 'request',
+                    slotName,
+                    data: requestData
+                })
+                const responseData = 56
+                channel.fakeReceive({
+                    type: 'response',
+                    id: request.id,
+                    slotName,
+                    data: responseData
+                })
+                return pendingPromise
+                    .then((response: number) => response.should.eql(responseData))
+            })
+
+            it('should reject a local pending request when an error is received', () => {
+                const pendingPromise = localHandler({ carrotType: 'blue' })
+                const { id } = channel.sendSpy.lastCall.args[0]
+                channel.fakeReceive({
+                    type: 'error',
+                    id,
+                    slotName,
+                    message: 'all out of blue'
+                })
+                return pendingPromise
+                    .then(() => {
+                        throw new Error('Promise should have been rejected')
+                    })
+                    .catch(err => `${err}`.should.eql('Error: all out of blue on getCarrotStock'))
+            })
+        })
+
+    })
+
+})


### PR DESCRIPTION
Almost comprehensive test suite for ts-event-bus internals.

Switched from `done` callbacks to Promise/async functions in existing tests where applicable.

Slightly changed typing of `Channel.onError` (which was anyway unsused internally), and made sure it was correctly used internally, so that a "generic" error on a channel causes the Transport to reject all pending requests.

Missing some tests on remote handler unsub, but I noticed that the functionality was kind of broken anyway, so might address that in a further PR.