### PR TITLE
Expose transport message interfaces

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,8 +1,10 @@
+import { TransportMessage } from './Message'
+
 export type OnMessageCallback = (message: {}) => void
 
 export interface Channel {
     timeout?: number
-    send: (message: {}) => void
+    send: (message: TransportMessage) => void
     onData: (cb: OnMessageCallback) => void
     onConnect: (cb: () => void) => void
     onDisconnect: (cb: () => void) => void
@@ -18,7 +20,7 @@ export abstract class GenericChannel implements Channel {
     private _onDisconnectCallbacks: Function[] = []
     private _onErrorCallbacks: Function[] = []
     private _ready = false
-    public abstract send(message: {}): void
+    public abstract send(message: TransportMessage): void
 
     public onData(cb: OnMessageCallback): void {
         if (this._onMessageCallbacks.indexOf(cb) === -1) {
@@ -41,7 +43,7 @@ export abstract class GenericChannel implements Channel {
         this._onErrorCallbacks.push(cb)
     }
 
-    protected _messageReceived(message: {}) {
+    protected _messageReceived(message: TransportMessage) {
         this._onMessageCallbacks.forEach(cb => cb(message))
     }
 

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,0 +1,10 @@
+
+export type TransportRequest = { type: 'request', slotName: string, id: string, data: any }
+export type TransportResponse = { type: 'response', slotName: string, id: string, data: any }
+export type TransportError = { type: 'error', slotName: string, id: string, message: string, stack?: string }
+export type TransportRegistrationMessage = { type: 'handler_registered', slotName: string }
+export type TransportMessage =
+    TransportRegistrationMessage
+    | TransportRequest
+    | TransportResponse
+    | TransportError

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -1,5 +1,12 @@
 import { Handler, callHandlers } from './Handler'
 import { Channel } from './Channel'
+import {
+    TransportRegistrationMessage,
+    TransportError,
+    TransportRequest,
+    TransportResponse,
+    TransportMessage
+} from './Message'
 
 let _ID = 0
 
@@ -16,16 +23,6 @@ const ERRORS = {
     REMOTE_CONNECTION_CLOSED: 'REMOTE_CONNECTION_CLOSED',
     CHANNEL_NOT_READY: 'CHANNEL_NOT_READY'
 }
-
-export type TransportRequest = { type: 'request', slotName: string, id: string, data: any }
-export type TransportResponse = { type: 'response', slotName: string, id: string, data: any }
-export type TransportError = { type: 'error', slotName: string, id: string, message: string, stack?: string }
-export type TransportRegistrationMessage = { type: 'handler_registered', slotName: string }
-export type TransportMessage =
-    TransportRegistrationMessage
-    | TransportRequest
-    | TransportResponse
-    | TransportError
 
 export type PendingRequest = {
     resolve: (data?: any) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { slot, Slot } from './Slot'
 export { EventDeclaration, combineEvents, createEventBus } from './Events'
 export { Channel, GenericChannel } from './Channel'
+export { TransportMessage } from './Message'

--- a/test/Event.test.ts
+++ b/test/Event.test.ts
@@ -3,7 +3,7 @@ import 'should'
 import {slot} from './../src/Slot'
 import {combineEvents, createEventBus} from './../src/Events'
 import {GenericChannel} from './../src/Channel'
-import {TransportMessage} from './../src/Transport'
+import {TransportMessage} from './../src/Message'
 import {TestChannel} from './TestChannel'
 import * as sinon from 'sinon'
 

--- a/test/TestChannel.ts
+++ b/test/TestChannel.ts
@@ -1,5 +1,4 @@
-import {GenericChannel} from './../src/Channel'
-import {TransportMessage} from './../src/Transport'
+import {TransportMessage, GenericChannel} from './../src/'
 import * as sinon from 'sinon'
 
 export class TestChannel extends GenericChannel {
@@ -23,7 +22,12 @@ export class TestChannel extends GenericChannel {
     }
 
     public callMessageReceived()  {
-        this._messageReceived({ type: 'test' })
+        this._messageReceived({
+            type: 'error',
+            slotName: 'test',
+            id: '1',
+            message: 'error'
+        })
     }
 
     public callError() {

--- a/test/Transport.test.ts
+++ b/test/Transport.test.ts
@@ -1,6 +1,7 @@
 import 'should'
 
-import { Transport, TransportMessage } from './../src/Transport'
+import { Transport } from './../src/Transport'
+import { TransportMessage } from './../src/Message'
 import { TestChannel } from './TestChannel'
 import * as sinon from 'sinon'
 import { createEventBus } from '../src/Events'


### PR DESCRIPTION
Allows developers to develop richer channels, by being informed about request IDs. Example of use cases: [http client channel](https://github.com/lguychard/ts-event-bus-client-channel) and [http server channel](https://github.com/lguychard/ts-event-bus-server-channel)