### PR TITLE
Call unregisterHandler on unsubscribe action

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -3,8 +3,10 @@ export type TransportRequest = { type: 'request', slotName: string, id: string, 
 export type TransportResponse = { type: 'response', slotName: string, id: string, data: any }
 export type TransportError = { type: 'error', slotName: string, id: string, message: string, stack?: string }
 export type TransportRegistrationMessage = { type: 'handler_registered', slotName: string }
+export type TransportUnregistrationMessage = { type: 'handler_unregistered', slotName: string }
 export type TransportMessage =
     TransportRegistrationMessage
+    | TransportUnregistrationMessage
     | TransportRequest
     | TransportResponse
     | TransportError

--- a/src/Slot.ts
+++ b/src/Slot.ts
@@ -102,6 +102,10 @@ export function connectSlot<T=void, T2=void>(slotName: string, transports: Trans
 
         // Return the unsubscription function
         return () => {
+
+            // Unregister remote handler with all of our remote transports
+            transports.forEach(t => t.unregisterHandler(slotName, handler))
+
             const ix = handlers.indexOf(handler)
             if (ix !== -1) {
                 handlers.splice(ix, 1)

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -2,6 +2,7 @@ import { Handler, callHandlers } from './Handler'
 import { Channel } from './Channel'
 import {
     TransportRegistrationMessage,
+    TransportUnregistrationMessage,
     TransportError,
     TransportRequest,
     TransportResponse,
@@ -74,6 +75,8 @@ export class Transport {
                     return this._responseReceived(message)
                 case 'handler_registered':
                     return this._registerRemoteHandler(message)
+                case 'handler_unregistered':
+                    return this._unregisterRemoteHandler(message.slotName)
                 case 'error':
                     return this._errorReceived(message)
                 default:
@@ -92,7 +95,7 @@ export class Transport {
             this._channelReady = false
 
             // When the far end disconnects, remove all the handlers it had set
-            this._unregisterHandlers()
+            this._unregisterAllRemoteHandlers()
             this._rejectAllPendingRequests(new Error(`${ERRORS.REMOTE_CONNECTION_CLOSED}`))
         })
 
@@ -212,15 +215,19 @@ export class Transport {
         addHandler(remoteHandler)
     }
 
-    private _unregisterHandlers(): void {
+    private _unregisterRemoteHandler(slotName: string): void {
+        const unregisterRemoteHandler = this._remoteHandlerDeletionCallbacks[slotName]
+        const remoteHandler = this._remoteHandlers[slotName]
+        if (remoteHandler && unregisterRemoteHandler) {
+            unregisterRemoteHandler(remoteHandler)
+            delete this._remoteHandlers[slotName]
+        }
+    }
+
+    private _unregisterAllRemoteHandlers(): void {
         Object.keys(this._remoteHandlerDeletionCallbacks)
             .forEach(slotName => {
-                const unregisterRemoteHandler = this._remoteHandlerDeletionCallbacks[slotName]
-                const remoteHandler = this._remoteHandlers[slotName]
-                if (remoteHandler && unregisterRemoteHandler) {
-                    unregisterRemoteHandler(remoteHandler)
-                    delete this._remoteHandlers[slotName]
-                }
+                this._unregisterRemoteHandler(slotName)
             })
     }
 
@@ -264,6 +271,7 @@ export class Transport {
             this._localHandlers[slotName] = []
         }
         this._localHandlers[slotName].push(handler)
+
         const registrationMessage: TransportRegistrationMessage = {
             type: 'handler_registered',
             slotName
@@ -274,4 +282,23 @@ export class Transport {
         }
     }
 
+    /**
+     * Called when a local handler is unregistered, to send a `handler_unregistered`
+     * message to the far end.
+     */
+    public unregisterHandler(slotName: string, handler: Handler<any, any>): void {
+        if (this._localHandlers[slotName]) {
+            const ix = this._localHandlers[slotName].indexOf(handler)
+            if (ix > -1) {
+                this._localHandlers[slotName].splice(ix)
+                const unregistrationMessage: TransportUnregistrationMessage = {
+                    type: 'handler_unregistered',
+                    slotName
+                }
+                if (this._channelReady) {
+                    this._channel.send(unregistrationMessage)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
When an unsubscribe callback is called for the last handler on a slot, we need to unregister the remote handler for each transport.

There needs to be only one remote handler defined whatever the count of local handlers. Therefore we only send `handler_registered` for the first handler registration, and `handler_unregistered` for the last handler unregistration.

The reason why I did some refactoring in the tests are:
 - I needed to be able to define multiple handlers per slot to test this new behaviour
 - I needed the test to be independent from each other instead of being sequential