### PR TITLE
Implement lazy slot capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,36 @@ EventBus.multiply.on(({a, b}) => {
 })
 ```
 
+### Lazy callbacks
+
+Slots expose a `lazy` method that will allow you to call a "connect" callback when a first
+client connects to the slot, and a "disconnect" callback when the last client disconnect.
+
+Remote or local clients are considered equally. If a client was already connected to the slot
+at the time when `lazy` is called, the "connect" callback is called immediately.
+
+```typescript
+const connect = () => {
+  console.log('Someone somewhere has begun listening to the slot with `.on`.')
+}
+
+const disconnect = () => {
+  console.log('No one is listening to the slot anymore.')
+}
+
+const disconnectLazy = EventBus.ping.lazy(connect, disconnect)
+
+const unsubscribe = EventBus.ping().on(() => { })
+// console output: 'Someone somewhere has begun listening to the slot with `.on`.'
+
+unsubscribe()
+// console output: 'No one is listening to the slot anymore.'
+
+// Remove the callbacks.
+// "disconnect" is called one last time if there were subscribers left on the slot.
+disconnectLazy()
+```
+
 ### Syntactic sugar
 
 You can combine events from different sources.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "event-bus"
   ],
   "resolutions": {
-    "js-yaml": ">=3.13.1"
+    "js-yaml": ">=3.13.1",
+    "lodash": ">=4.17.11"
   },
   "license": "Apache-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,9 +2095,10 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash@^4.17.4:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+lodash@>=4.17.11, lodash@^4.17.4:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lolex@^2.2.0, lolex@^2.3.2:
   version "2.3.2"


### PR DESCRIPTION
I'm proposing this implementation of a lazy slot capacity where a first "connect" callback is called when a first remote client connects to the slot, and a second "disconnect" callback is called when the last remote client unsubscribes from the slot.

The objective is to use it to "pipe" observables through the event-bus like so:

```
const data$ = getDataObservable(...)
let subscription
const connect = () => subscription = data$.subscribe(e => slot(e))
const disconnect = () => if (subscription && subscription.unsubscribe) subscription.unsubscribe()
slot.lazy(connect, disconnect)
```

The advantage of this way over the simple:

```
data$.on(e => slot(e))
```

Is that the former only subscribe to observables when a client need them, saving calculations when the later would force us to subscribe to all our observables always, which is not suitable for a full live api.
