### PR TITLE
feat: remove the max parameters limit from combineEvents

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -6,25 +6,20 @@ export interface EventDeclaration {
     [slotName: string]: Slot<any, any>
 }
 
+// Explanation to how this type function: https://fettblog.eu/typescript-union-to-intersection/
+// tl;dr Wrapping and unwrapping the generic into a fn force the unions to be an intersection
+type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (
+    x: infer R
+) => any
+    ? R
+    : never
+
 export function combineEvents<
-    C1 extends EventDeclaration, C2 extends EventDeclaration, C3 extends EventDeclaration,
-    C4 extends EventDeclaration, C5 extends EventDeclaration, C6 extends EventDeclaration,
-    C7 extends EventDeclaration, C8 extends EventDeclaration, C9 extends EventDeclaration,
-    C10 extends EventDeclaration, C11 extends EventDeclaration, C12 extends EventDeclaration,
-    C13 extends EventDeclaration, C14 extends EventDeclaration, C15 extends EventDeclaration,
-    C16 extends EventDeclaration, C17 extends EventDeclaration, C18 extends EventDeclaration,
-    C19 extends EventDeclaration, C20 extends EventDeclaration, C21 extends EventDeclaration,
-    C22 extends EventDeclaration, C23 extends EventDeclaration, C24 extends EventDeclaration
+    Events extends EventDeclaration[]
 >(
-    _c1: C1, _c2: C2, _c3?: C3, _c4?: C4, _c5?: C5, _c6?: C6, _c7?: C7, _c8?: C8,
-    _c9?: C9, _c10?: C10, _c11?: C11, _c12?: C12, _c13?: C13, _c14?: C14, _c15?: C15,
-    _c16?: C16, _c17?: C17, _c18?: C18, _c19?: C19, _c20?: C20, _c21?: C21, _c22?: C22,
-    _c23?: C23, _c24?: C24
-): C1 & C2 & C3 & C4 & C5 & C6 & C7 & C8 & C9 & C10 & C11 & C12 & C13 & C14 & C15 & C16
-    & C17 & C18 & C19 & C20 & C21 & C22 & C23 & C24 {
-
-    const args = Array.from(arguments)
-
+    ...args: Events
+    // Using `Events[number]` to get the values inside the indexed array
+): UnionToIntersection<Events[number]> {
     const keys = args.reduce((acc, arg) => {
         acc.push.apply(acc, Object.keys(arg))
         return acc

--- a/yarn.lock
+++ b/yarn.lock
@@ -3331,9 +3331,9 @@ lodash.sortby@^4.7.0:
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash@^4.17.19:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
### Changes:
- Remove the limit of 24 parameters for `combineEvents` by using the Spread typing 
- Update `yarn.lock` for audit warning purpose