### PR TITLE
feat(buffer): disable event buffering by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,16 @@ disconnectLazy()
 
 ### Buffering
 
-When the eventBus is created with channels, slots will wait for all transports to have
-registered callbacks before triggering.
+When the eventBus is created with channels, slots will not wait for all
+transports to have registered callbacks before triggering.
 
-This buffering mechanism can be disabled at the slot level with the `noBuffer` config option:
+This buffering mechanism can be enabled at the slot level with the `buffer`
+config option explicitly set to `true`:
 
 ```typescript
 const MyEvents = {
     willWait: slot<string>(),
-    wontWait: slot<string>({ noBuffer: true }),
+    wontWait: slot<string>({ buffer: true }),
 }
 ```
 

--- a/src/Slot.ts
+++ b/src/Slot.ts
@@ -5,12 +5,12 @@ import { DEFAULT_PARAM } from './Constants'
 const signalNotConnected = () => { throw new Error('Slot not connected') }
 
 interface SlotConfig {
-    // This option will prevent the slot from buffering the
-    // requests if no remote handlers are set for some transports.
-    noBuffer?: boolean
+    // This option will enable the slot to buffer the requests and wait
+    // for all remote handlers to be set for some transports.
+    buffer?: boolean
 }
 
-export const defaultSlotConfig = { noBuffer: false }
+export const defaultSlotConfig = { buffer: false }
 
 const getNotConnectedSlot = (config: SlotConfig): Slot<any, any> =>
     Object.assign(
@@ -220,7 +220,7 @@ export function connectSlot<T = void, T2 = void>(
         const data: any = paramUsed ? secondArg : firstArg
         const param: string = paramUsed ? firstArg : DEFAULT_PARAM
 
-        if (config.noBuffer || transports.length === 0) {
+        if (!config.buffer || transports.length === 0) {
             const allParamHandlers = getParamHandlers(param, handlers)
             return callHandlers(data, allParamHandlers)
         }

--- a/test/Slot.spec.ts
+++ b/test/Slot.spec.ts
@@ -20,7 +20,7 @@ describe('slot', () => {
         expect(testSlot.config).toEqual(defaultSlotConfig)
     })
     it('should set config passed as argument', () => {
-        const config = { noBuffer: true }
+        const config = { buffer: true }
         const testSlot = slot(config)
         if (!testSlot.config) {
             throw new Error('testSlot should have a config')
@@ -131,77 +131,77 @@ describe('connectSlot', () => {
 
     describe('with local and remote handlers', () => {
 
-        it('should call both local handlers and remote handlers', async () => {
+        it('should call local handlers even if no remote handler is registered', async () => {
             const { channel, transport } = makeTestTransport()
-            const broadcastBool = connectSlot<boolean>('broadcastBool', [transport])
+            const broadcastBool = connectSlot<boolean>( 'broadcastBool', [transport])
             let localCalled = false
             broadcastBool.on(_b => { localCalled = true })
-            const triggerPromise = broadcastBool(true)
+            broadcastBool(true)
 
-            // Handlers should not be called until a remote handler is registered
-            await Promise.resolve()
-            expect(localCalled).toEqual(false)
+            // We should have called the trigger
+            expect(localCalled).toEqual(true)
 
-            channel.fakeReceive({
+            const registrationMessage: TransportRegistrationMessage = {
                 param: DEFAULT_PARAM,
                 slotName: 'broadcastBool',
                 type: 'handler_registered'
-            })
+            }
 
-            // setTimeout(0) to yield control to ts-event-bus internals,
-            // so that the call to handlers can be processed
+            channel.fakeReceive(registrationMessage)
             await new Promise(resolve => setTimeout(resolve, 0))
 
-            // Once a remote handler is registered, both local and remote should be called
-            expect(localCalled).toEqual(true)
-            const request = channel.sendSpy.mock.calls[channel.sendSpy.mock.calls.length - 1][0]
-
-            expect(request).toMatchObject({
-                data: true,
-                param: DEFAULT_PARAM,
-                slotName: 'broadcastBool',
-                type: 'request'
-            })
-
-            // triggerPromise should resolve once a remote response is received
-            channel.fakeReceive({
-                data: null,
-                id: request.id,
-                param: DEFAULT_PARAM,
-                slotName: 'broadcastBool',
-                type: 'response'
-            })
-            await triggerPromise
+            // Remote should not have been called, as it was not registered
+            // at the time of the trigger.
+            const request = channel.sendSpy.mock.calls[0]
+            expect(request).toMatchObject(request)
         })
 
-        describe('noBuffer', () => {
-            it('should call local handlers even if no remote handler is registered', async () => {
+        describe('buffer', () => {
+            it('should call both local handlers and remote handlers', async () => {
                 const { channel, transport } = makeTestTransport()
                 const broadcastBool = connectSlot<boolean>(
                     'broadcastBool',
                     [transport],
-                    { noBuffer: true }
+                    { buffer: true }
                 )
                 let localCalled = false
                 broadcastBool.on(_b => { localCalled = true })
-                broadcastBool(true)
+                const triggerPromise = broadcastBool(true)
 
-                // We should have called the trigger
-                expect(localCalled).toEqual(true)
+                // Handlers should not be called until a remote handler is registered
+                await Promise.resolve()
+                expect(localCalled).toEqual(false)
 
-                const registrationMessage: TransportRegistrationMessage = {
+                channel.fakeReceive({
                     param: DEFAULT_PARAM,
                     slotName: 'broadcastBool',
                     type: 'handler_registered'
-                }
+                })
 
-                channel.fakeReceive(registrationMessage)
+                // setTimeout(0) to yield control to ts-event-bus internals,
+                // so that the call to handlers can be processed
                 await new Promise(resolve => setTimeout(resolve, 0))
 
-                // Remote should not have been called, as it was not registered
-                // at the time of the trigger.
-                const request = channel.sendSpy.mock.calls[0]
-                expect(request).toMatchObject(request)
+                // Once a remote handler is registered, both local and remote should be called
+                expect(localCalled).toEqual(true)
+                const request = channel.sendSpy.mock.calls[channel.sendSpy.mock.calls.length - 1][0]
+
+                expect(request).toMatchObject({
+                    data: true,
+                    param: DEFAULT_PARAM,
+                    slotName: 'broadcastBool',
+                    type: 'request'
+                })
+
+                // triggerPromise should resolve once a remote response is received
+                channel.fakeReceive({
+                    data: null,
+                    id: request.id,
+                    param: DEFAULT_PARAM,
+                    slotName: 'broadcastBool',
+                    type: 'response'
+                })
+                await triggerPromise
             })
         })
 


### PR DESCRIPTION
Disable buffering by default so we don't wait for all transports to have registered callbacks before triggering events. Advocating for a change in design here as there are fundamental issues caused by waiting for all registrations across channels unless intended. I'm not sure how we should consider bumping versions exactly and if this should be considered a MAJOR change or not.