### PR TITLE
Implement GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - LICENSE
+      - '*.md'
+      - '*.svg'
+      - 'examples/**'
+      - .editorconfig
+      - .gitignore
+      - .npmrc
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - LICENSE
+      - '*.md'
+      - '*.svg'
+      - 'examples/**'
+      - .editorconfig
+      - .gitignore
+      - .npmrc
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build library
+        run: yarn build
+
+      - name: Run tests
+        run: yarn run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-script:
-  "npm run ci"
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ts-event-bus
 [![by Dashlane](https://rawgit.com/dashlane/ts-event-bus/master/by_dashlane.svg)](https://www.dashlane.com/)
 
-[![Build Status](https://travis-ci.org/Dashlane/ts-event-bus.svg?branch=master)](https://travis-ci.org/Dashlane/ts-event-bus)
+[![Build Status](https://github.com/Dashlane/ts-event-bus/actions/workflows/build.yml/badge.svg)](https://github.com/Dashlane/ts-event-bus/actions/workflows/build.yml)
 [![Dependency Status](https://david-dm.org/Dashlane/ts-event-bus.svg)](https://david-dm.org/Dashlane/ts-event-bus)
 
 Distributed messaging in Typescript


### PR DESCRIPTION
- Dropped Node 13 since [it’s unsupported](https://nodejs.org/en/about/releases/)
- Test Node 14 et 16 (two current LTS versions)
- CI only starts if we touch code, tests or build/lint configuration
- Use `actions/checkout@v2` and `actions/setup-node@v2` instead of their v1
- Removed the Travis CI configuration file

Remake of #14 