### PR TITLE
Feat/channel autoreconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ const MyEvents = {
 
 In order to re-establish a lost connection when triggering an event a `Channel`
 needs to implement the `autoReconnect` method.
+See example: [RuntimeConnect](./examples/channels/RuntimeConnect.ts)
 It's also possible to fine tune and deactivate this feature on a per-slot basis :
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ const MyEvents = {
 };
 ```
 
+### Auto-reconnection
+
+In order to re-establish a lost connection when triggering an event a `Channel`
+needs to implement the `autoReconnect` method.
+It's also possible to fine tune and deactivate this feature on a per-slot basis :
+
+```typescript
+const MyEvents = {
+  willAutoReconnect: slot<string>(),
+  wontNotAutoReconnect: slot<string>({ autoReconnect: false }),
+};
+```
+
 ### Syntactic sugar
 
 You can combine events from different sources.

--- a/examples/channels/NativeWebSocket.ts
+++ b/examples/channels/NativeWebSocket.ts
@@ -1,4 +1,4 @@
-import { GenericChannel } from './../../src/Channel'
+import { GenericChannel } from './../../src/Channels/GenericChannel'
 
 export class WebSocketClientChannel extends GenericChannel {
     private static MAX_RETRIES = 3

--- a/examples/channels/RuntimeConnect.ts
+++ b/examples/channels/RuntimeConnect.ts
@@ -50,16 +50,14 @@ export class RuntimeConnect extends GenericChannel {
      * connection status when initiating a connection
      */
     private setup(portName: PortNames) {
-        if (self.chrome) {
-            this.port = chrome.runtime.connect({ name: portName });
-            this.port.onMessage.addListener((message: TransportMessage) =>
-                this._messageReceived(message)
-            );
-            this.port.onDisconnect.addListener(() => {
-                this.port = undefined;
-                this._disconnected();
-            });
-            this._connected();
-        }
+        this.port = chrome.runtime.connect({ name: portName });
+        this.port.onMessage.addListener((message: TransportMessage) =>
+            this._messageReceived(message)
+        );
+        this.port.onDisconnect.addListener(() => {
+            this.port = undefined;
+            this._disconnected();
+        });
+        this._connected();
     }
 }

--- a/examples/channels/RuntimeConnect.ts
+++ b/examples/channels/RuntimeConnect.ts
@@ -1,0 +1,65 @@
+import { GenericChannel } from './../../src/Channels/GenericChannel'
+import { TransportMessage } from './../../src/Message'
+
+
+export enum PortNames {
+    PortOne = 'PortOne',
+    PortTwo = 'PortTwo',
+}
+
+/**
+ * Channel used in an MV3 extension context
+ * Connection with a Service Worker background script
+ */
+export class RuntimeConnect extends GenericChannel {
+    public constructor(name: PortNames) {
+        super();
+        this.name = name;
+    }
+
+    private name: PortNames;
+
+    private port: chrome.runtime.Port | undefined;
+
+    /**
+     * Initiate a port connection
+     */
+    public connect() {
+        this.setup(this.name);
+    }
+
+    /**
+     * Automatically called when a Slot is triggered and the channel is disconnected
+     */
+    public autoReconnect() {
+        this.connect();
+    }
+
+    /**
+     * Send a message through the given port
+     */
+    public send(message: any): void {
+        if (!this.port) {
+            throw new Error('No port to send message');
+        }
+        this.port.postMessage(message);
+    }
+
+    /**
+     * Setup incoming message handling, disconnections, and
+     * connection status when initiating a connection
+     */
+    private setup(portName: PortNames) {
+        if (self.chrome) {
+            this.port = chrome.runtime.connect({ name: portName });
+            this.port.onMessage.addListener((message: TransportMessage) =>
+                this._messageReceived(message)
+            );
+            this.port.onDisconnect.addListener(() => {
+                this.port = undefined;
+                this._disconnected();
+            });
+            this._connected();
+        }
+    }
+}

--- a/examples/channels/WebSocket.ts
+++ b/examples/channels/WebSocket.ts
@@ -1,6 +1,6 @@
 import * as WebSocket from 'ws'
 import { Server as WebSocketServer } from 'ws'
-import { GenericChannel } from './../../src/Channel'
+import { GenericChannel } from './../../src/Channels/GenericChannel'
 
 export class WebSocketClientChannel extends GenericChannel {
 

--- a/examples/channels/Worker.ts
+++ b/examples/channels/Worker.ts
@@ -1,4 +1,4 @@
-import { GenericChannel } from './../../src/Channel'
+import { GenericChannel } from './../../src/Channels/GenericChannel'
 
 export class WorkerChannel extends GenericChannel {
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
+    "@types/chrome": "^0.0.155",
     "@types/jest": "^26.0.20",
     "@types/ws": "^3.2.1",
     "husky": "^4.3.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "tslint": "^5.6.0",
-    "typescript": "^4.1.3",
+    "typescript": "~4.1.3",
     "typescript-formatter": "^7.2.2",
     "ws": "^3.3.2"
   },

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -7,7 +7,7 @@ export interface Channel {
     /**
      * Orders the channel to reconnect.
      *
-     * @remarks To implement in order to beneficiate from the auto-reconnect feature.
+     * @remarks To implement in order to benefit from the auto-reconnect feature.
      * See the {@link ../README.md | README} for more context.
      */
     autoReconnect?: () => void

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -4,6 +4,7 @@ export type OnMessageCallback = (message: {}) => void
 
 export interface Channel {
     timeout: number
+    autoReconnect: () => void
     send: (message: TransportMessage) => void
     onData: (cb: OnMessageCallback) => void
     onConnect: (cb: () => void) => void

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -4,7 +4,13 @@ export type OnMessageCallback = (message: {}) => void
 
 export interface Channel {
     timeout: number
-    autoReconnect: () => void
+    /**
+     * Orders the channel to reconnect.
+     *
+     * @remarks To implement in order to beneficiate from the auto-reconnect feature.
+     * See the {@link ../README.md | README} for more context.
+     */
+    autoReconnect?: () => void
     send: (message: TransportMessage) => void
     onData: (cb: OnMessageCallback) => void
     onConnect: (cb: () => void) => void

--- a/src/Channels/GenericChannel.ts
+++ b/src/Channels/GenericChannel.ts
@@ -22,7 +22,7 @@ export abstract class GenericChannel implements Channel {
      * Allows to automatically reconnecting the channel when a slot is triggered but the connection is interrupted
      * Override this method to enable it
      */
-    public autoReconnect(): void {}
+    public autoReconnect(): void { }
 
     public onData(cb: OnMessageCallback): void {
         if (this._onMessageCallbacks.indexOf(cb) === -1) {

--- a/src/Channels/GenericChannel.ts
+++ b/src/Channels/GenericChannel.ts
@@ -18,12 +18,6 @@ export abstract class GenericChannel implements Channel {
 
     public abstract send(message: TransportMessage): void
 
-    /**
-     * Allows to automatically reconnecting the channel when a slot is triggered but the connection is interrupted
-     * Override this method to enable it
-     */
-    public autoReconnect(): void { }
-
     public onData(cb: OnMessageCallback): void {
         if (this._onMessageCallbacks.indexOf(cb) === -1) {
             this._onMessageCallbacks.push(cb)

--- a/src/Channels/GenericChannel.ts
+++ b/src/Channels/GenericChannel.ts
@@ -18,6 +18,12 @@ export abstract class GenericChannel implements Channel {
 
     public abstract send(message: TransportMessage): void
 
+    /**
+     * Allows to automatically reconnecting the channel when a slot is triggered but the connection is interrupted
+     * Override this method to enable it
+     */
+    public autoReconnect(): void {}
+
     public onData(cb: OnMessageCallback): void {
         if (this._onMessageCallbacks.indexOf(cb) === -1) {
             this._onMessageCallbacks.push(cb)

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -364,4 +364,35 @@ export class Transport {
             }
         }
     }
+
+    /**
+     * Allows to know the transport status and to perform a reconnection
+     *
+     * @returns {boolean} Transport's channel connection status, true if disconnected, otherwise false
+     */
+    public isDisconnected(): boolean {
+        return !this._channelReady
+    }
+
+    /**
+     * Auto-reconnect the channel
+     * see Slot.trigger function for usage
+     *
+     * @returns {Promise} A promise resolving when the connection is established
+     */
+    public autoReconnect(): Promise<any> {
+        if (this.isDisconnected()) {
+            const promise = new Promise<void>((resolve) => {
+                this._channel.onConnect(() => {
+                    return resolve()
+                })
+            })
+            this._channel.autoReconnect()
+
+            return promise
+        }
+        else {
+            return Promise.resolve()
+        }
+    }
 }

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -380,8 +380,8 @@ export class Transport {
      *
      * @returns {Promise} A promise resolving when the connection is established
      */
-    public autoReconnect(): Promise<any> {
-        if (this.isDisconnected()) {
+    public autoReconnect(): Promise<void> {
+        if (this.isDisconnected() && this._channel.autoReconnect) {
             const promise = new Promise<void>((resolve) => {
                 this._channel.onConnect(() => {
                     return resolve()
@@ -391,8 +391,7 @@ export class Transport {
 
             return promise
         }
-        else {
-            return Promise.resolve()
-        }
+
+        return Promise.resolve()
     }
 }

--- a/test/Slot.spec.ts
+++ b/test/Slot.spec.ts
@@ -184,7 +184,7 @@ describe('connectSlot', () => {
                 )
                 let localCalled = false
                 broadcastBool.on(_b => { localCalled = true })
-                broadcastBool(true)
+                await broadcastBool(true)
 
                 // We should have called the trigger
                 expect(localCalled).toEqual(true)

--- a/test/TestChannel.ts
+++ b/test/TestChannel.ts
@@ -40,9 +40,9 @@ export class TestChannel extends GenericChannel {
     }
 
     public autoReconnect() {
-        this.callConnected();
+        this.callConnected()
 
-        this.autoReconnectSpy();
+        this.autoReconnectSpy()
     }
 
     public send(message: TransportMessage) {

--- a/test/TestChannel.ts
+++ b/test/TestChannel.ts
@@ -7,6 +7,8 @@ export class TestChannel extends GenericChannel {
 
     public sendSpy = jest.fn()
 
+    public autoReconnectSpy = jest.fn()
+
     constructor() {
         super()
     }
@@ -35,6 +37,12 @@ export class TestChannel extends GenericChannel {
 
     public callError() {
         this._error(new Error('LOLOL'))
+    }
+
+    public autoReconnect() {
+        this.callConnected();
+
+        this.autoReconnectSpy();
     }
 
     public send(message: TransportMessage) {

--- a/test/Transport.spec.ts
+++ b/test/Transport.spec.ts
@@ -244,4 +244,82 @@ describe('Transport', () => {
             })
         })
     })
+
+    describe('channel connection status', () => {
+
+        let channel: TestChannel
+        let transport: Transport
+
+        beforeEach(() => {
+            jest.resetAllMocks()
+            channel = new TestChannel()
+            transport = new Transport(channel)
+            channel.callConnected()
+        })
+
+        it('should be indicated as connected', () => {
+            expect(transport.isDisconnected()).toEqual(false)
+        })
+
+        it('should be indicated as disconnected', () => {
+            // Disconnect channel
+            channel.callDisconnected()
+
+            expect(transport.isDisconnected()).toEqual(true)
+        })
+
+    })
+
+    describe('channel autoreconnect', () => {
+
+        let channel: TestChannel
+        let transport: Transport
+
+        beforeEach(() => {
+            jest.resetAllMocks()
+            channel = new TestChannel()
+            transport = new Transport(channel)
+        })
+
+        describe('when already connected', () => {
+            beforeEach(() => {
+                jest.resetAllMocks()
+                channel.autoReconnectSpy.mockClear()
+                channel.callConnected()
+            })
+
+            it('should not call the channel autoReconnect method', () => {
+                transport.autoReconnect()
+                expect(channel.autoReconnectSpy).not.toHaveBeenCalled()
+            })
+
+            it('should not call the channel onConnect method', () => {
+                Object.defineProperty(channel, 'onConnect', { value: jest.fn() })
+                transport.autoReconnect()
+
+                expect(channel['onConnect']).not.toHaveBeenCalled()
+            })
+        })
+
+        describe('when disconnected', () => {
+            beforeEach(() => {
+                jest.resetAllMocks()
+                channel.autoReconnectSpy.mockClear()
+                channel.callDisconnected()
+            })
+
+            it('should call the channel autoReconnect method', () => {
+                transport.autoReconnect()
+                expect(channel.autoReconnectSpy).toHaveBeenCalled()
+            })
+
+            it('should call the channel onConnect method', () => {
+                Object.defineProperty(channel, 'onConnect', { value: jest.fn() })
+                transport.autoReconnect()
+
+                expect(channel['onConnect']).toHaveBeenCalledTimes(1)
+            })
+
+        })
+    })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,12 +1134,37 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chrome@^0.0.155":
+  version "0.0.155"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.155.tgz#8d5ebb4f57d050a280634cae279e28256eb70955"
+  integrity sha512-y21uDq+SXa253hddPUHABvkYFO7GuhUwxjuh+xaHYDW+3/4GepgKJ8oKQoMEf0pA9PwH3JsBSCKMJvgd6Nk4xQ==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
+"@types/filesystem@*":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
+  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
+  integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
   integrity sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==
   dependencies:
     "@types/node" "*"
+
+"@types/har-format@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.7.tgz#debfe36378f26c4fc2abca1df99f00a8ff94fd29"
+  integrity sha512-/TPzUG0tJn5x1TUcVLlDx2LqbE58hyOzDVAc9kf8SpOEmguHjU6bKUyfqb211AdqLOmU/SNyXvLKPNP5qTlfRw==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4698,10 +4698,10 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@~4.1.3:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
 ultron@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Not finalized yet:

[Breaking change]
Before:
With the noBuffer option or if no remote transport was existing (only the local one), the event return was a synchronous one

Now:
All the events a asynchronous

INFO FOR REVIEWER:
- Check it commit by commit

INFO ABOUT CHUNCK CHANNEL
- The loss of the connection has to be managed in the send method, nothing to add