### PR TITLE
Export Unsubscribe type to clients of ts-event-bus

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { slot, Slot } from './Slot'
+export { slot, Slot, Unsubscribe } from './Slot'
 export { EventDeclaration, combineEvents, createEventBus } from './Events'
 export { Channel } from './Channel'
 export { GenericChannel } from './Channels/GenericChannel'


### PR DESCRIPTION
This type is already public for clients given that it is returned by
Slot<T>.on() so it should be available to them directly.

This allows me as a client to redeclare a `SubType` for `Slot<T>` where `.on()` always expects a Promise instead of also accepting a value that is returned `synchronously`. This allows me to have an event bus were it is less likely for a handler to "forget" to reply after handling an event.