### PR TITLE
Feat/dont await for non interested remotes

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -51,12 +51,9 @@ export function createEventBus<C extends EventDeclaration>(args: {
     channels?: Channel[]
     blackList?: Array<keyof C>
 }): C {
-    const filteredEventList = args.blackList
-        ? Object.keys(omitEvents(args.events, args.blackList))
-        : undefined
 
     const transports = (args.channels || []).map(
-        (c) => new Transport(c, filteredEventList)
+        (c) => new Transport(c, (args.blackList as string[]))
     )
 
     const eventBus: Partial<C> = {}

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -49,11 +49,11 @@ export function omitEvents<
 export function createEventBus<C extends EventDeclaration>(args: {
     events: C
     channels?: Channel[]
-    blackList?: Array<keyof C>
+    ignoredEvents?: Array<keyof C>
 }): C {
 
     const transports = (args.channels || []).map(
-        (c) => new Transport(c, (args.blackList as string[]))
+        (c) => new Transport(c, (args.ignoredEvents as string[]))
     )
 
     const eventBus: Partial<C> = {}

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -36,6 +36,17 @@ export function combineEvents<
 
 export function createEventBus<C extends EventDeclaration>(args: { events: C, channels?: Channel[] }): C {
     const transports = (args.channels || []).map(c => new Transport(c))
+export function omitEvents<
+    Events extends EventDeclaration,
+    OmittedEvents extends keyof Events
+>(events: Events, omittedEvents: OmittedEvents[]): Omit<Events, OmittedEvents> {
+    return Object.keys(events).reduce((acc, event) => {
+        if (!omittedEvents.includes(event as OmittedEvents)) {
+            acc[event as keyof Events] = events[event]
+        }
+        return acc
+    }, {} as any)
+}
 
     const eventBus: Partial<C> = {}
     for (const event in args.events) {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -37,7 +37,7 @@ export type TransportUnregistrationMessage = {
 
 export type TransportEventListMessage = {
     type: 'event_list',
-    eventList: string[]
+    blackList: string[]
 }
 
 export type TransportMessage =

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -37,7 +37,7 @@ export type TransportUnregistrationMessage = {
 
 export type TransportEventListMessage = {
     type: 'event_list',
-    blackList: string[]
+    ignoredEvents: string[]
 }
 
 export type TransportMessage =

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -28,17 +28,25 @@ export type TransportRegistrationMessage = {
     slotName: string,
     param: string
 }
+
 export type TransportUnregistrationMessage = {
     type: 'handler_unregistered',
     slotName: string,
     param: string
 }
+
+export type TransportEventListMessage = {
+    type: 'event_list',
+    eventList: string[]
+}
+
 export type TransportMessage =
     TransportError
     | TransportRegistrationMessage
     | TransportRequest
     | TransportResponse
     | TransportUnregistrationMessage
+    | TransportEventListMessage
 
 export function isTransportMessage(m: { type: string }): m is TransportMessage {
     switch (m.type) {
@@ -47,6 +55,7 @@ export function isTransportMessage(m: { type: string }): m is TransportMessage {
         case 'error':
         case 'handler_unregistered':
         case 'handler_registered':
+        case 'event_list':
             return true
         default:
             return false

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -89,7 +89,7 @@ export class Transport {
 
     private _channelReady = false
 
-    constructor(private _channel: Channel, event_list?: string[]) {
+    constructor(private _channel: Channel, blackList?: string[]) {
         this._channel.onData((message: TransportMessage) => {
             switch (message.type) {
                 case 'request':
@@ -123,10 +123,10 @@ export class Transport {
             // a specific slot, and when NOT to wait.
             // This is necessary only when some events have been blacklisted
             // when calling createEventBus
-            if (event_list) {
+            if (blackList) {
                 this._channel.send({
                     type: "event_list",
-                    eventList: event_list
+                    blackList
                 })
             }
         })
@@ -151,11 +151,11 @@ export class Transport {
     * to be able to trigger them.
     */
     private _remoteEventListReceived({
-        eventList
+        blackList
     }: TransportEventListMessage): void {
         Object.keys(this._remoteEventListChangedCallbacks).forEach(
             (slotName) => {
-                if (!eventList.includes(slotName)) {
+                if (blackList.includes(slotName)) {
                     this._remoteEventListChangedCallbacks[slotName]()
                 }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ export { slot, Slot } from './Slot'
 export {
     EventDeclaration,
     combineEvents,
-    createEventBus,
-    omitEvents
+    createEventBus
 } from './Events'
 export { Channel } from './Channel'
 export { GenericChannel } from './Channels/GenericChannel'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { slot, Slot } from './Slot'
-export { EventDeclaration, combineEvents, createEventBus } from './Events'
+export {
+    EventDeclaration,
+    combineEvents,
+    createEventBus,
+    omitEvents
+} from './Events'
 export { Channel } from './Channel'
 export { GenericChannel } from './Channels/GenericChannel'
 export { ChunkedChannel } from './Channels/ChunkedChannel'

--- a/test/Event.spec.ts
+++ b/test/Event.spec.ts
@@ -1,5 +1,5 @@
 import { slot } from './../src/Slot'
-import { combineEvents, createEventBus } from './../src/Events'
+import { combineEvents, createEventBus, omitEvents } from './../src/Events'
 import { TestChannel } from './TestChannel'
 import { DEFAULT_PARAM } from './../src/Constants'
 
@@ -39,6 +39,32 @@ describe('combineEvents()', () => {
         expect(failing).toThrowError(/duplicate slots/)
     })
 
+})
+
+describe('omitEvent()', () => {
+    it('should omit events from the the list', () => {
+        const events = {
+            hello: slot<{ name: string }>(),
+            how: slot<{ mode: 'simple' | 'advanced' }>(),
+            are: slot<{ tense: number }>(),
+            you: slot<{ reflective: boolean }>(),
+        }
+
+        const filteredList = omitEvents(events, ['hello'])
+        expect(Object.keys(filteredList)).toEqual(['how', 'are', 'you'])
+    })
+
+    it('should return the list of all event when omitted list is empty', () => {
+        const events = {
+            hello: slot<{ name: string }>(),
+            how: slot<{ mode: 'simple' | 'advanced' }>(),
+            are: slot<{ tense: number }>(),
+            you: slot<{ reflective: boolean }>(),
+        }
+
+        const filteredList = omitEvents(events, [])
+        expect(Object.keys(filteredList)).toEqual(Object.keys(events))
+    })
 })
 
 describe('createEventBus()', () => {

--- a/test/Event.spec.ts
+++ b/test/Event.spec.ts
@@ -41,36 +41,11 @@ describe('combineEvents()', () => {
 
 })
 
-describe('omitEvent()', () => {
-    it('should omit events from the the list', () => {
-        const events = {
-            hello: slot<{ name: string }>(),
-            how: slot<{ mode: 'simple' | 'advanced' }>(),
-            are: slot<{ tense: number }>(),
-            you: slot<{ reflective: boolean }>(),
-        }
-
-        const filteredList = omitEvents(events, ['hello'])
-        expect(Object.keys(filteredList)).toEqual(['how', 'are', 'you'])
-    })
-
-    it('should return the list of all event when omitted list is empty', () => {
-        const events = {
-            hello: slot<{ name: string }>(),
-            how: slot<{ mode: 'simple' | 'advanced' }>(),
-            are: slot<{ tense: number }>(),
-            you: slot<{ reflective: boolean }>(),
-        }
-
-        const filteredList = omitEvents(events, [])
-        expect(Object.keys(filteredList)).toEqual(Object.keys(events))
-    })
-})
-
 describe('createEventBus()', () => {
 
     const events = {
-        numberToString: slot<number, string>()
+        numberToString: slot<number, string>(),
+        eventToIgnore: slot<void, void>()
     }
 
     const param = DEFAULT_PARAM
@@ -126,5 +101,25 @@ describe('createEventBus()', () => {
             id: '0',
             data: '5'
         })
+    })
+
+    describe('when a ignored list is passed to createEventBus()', () => {
+      it('should not connect the ignored slot and should return a filtered eventBus', () => {
+        const channel = new TestChannel()
+        const eventBus = createEventBus({
+            events,
+            channels: [channel],
+            ignoredEvents: ['eventToIgnore']
+        })
+        channel.callConnected()
+        const isIncluded = Object.keys(eventBus).includes('eventToIgnore')
+        expect(isIncluded).toBe(false)
+        // An event_list message should have been received with the list of
+        // ignoredEvents
+        expect(channel.sendSpy).toHaveBeenCalledWith({
+            type: 'event_list',
+            ignoredEvents: ['eventToIgnore']
+        })
+      })
     })
 })

--- a/test/Slot.spec.ts
+++ b/test/Slot.spec.ts
@@ -385,7 +385,7 @@ describe('connectSlot', () => {
             })
         })
 
-        describe('an empty event is list sent to one endpoint (A)', () => {
+        describe('a blacklist is sent to one endpoint (A)', () => {
             it('should NOT wait for remote endpoint A but SHOULD wait on remote endpoint B to have signaled registration before sending the event', async () => {
                 const { channel: channelA, transport: transportA } =
                     makeTestTransport()
@@ -397,10 +397,10 @@ describe('connectSlot', () => {
                     transportB,
                 ])
 
-                // Receiving an empty list is the same as blacklisting all events
+                // Receiving a black list of events
                 channelA.fakeReceive({
                     type: 'event_list',
-                    eventList: [],
+                    blackList: ['broadcastBool'],
                 })
 
                 // This will be called only when B is ready we don't care about
@@ -429,10 +429,10 @@ describe('connectSlot', () => {
             })
         })
 
-        describe('an event list is sent to one endpoint (A)', () => {
+        describe('an empty blacklist is sent to one endpoint (A)', () => {
             // This is the same test as before. But this time the because the
-            // event IS in the white list, we need to wait for A AND B to be
-            // registered to trigger the event
+            // blackList is empty, we need to wait for A AND B to be registered
+            // to trigger the event
             it('should wait for remote endpoint A and remote endpoint B to have signaled registration before sending the event', async () => {
                 const { channel: channelA, transport: transportA } =
                     makeTestTransport()
@@ -452,7 +452,7 @@ describe('connectSlot', () => {
 
                 channelA.fakeReceive({
                     type: 'event_list',
-                    eventList: ['broadcastBool'],
+                    blackList: [],
                 })
 
                 broadcastBool(true)

--- a/test/Slot.spec.ts
+++ b/test/Slot.spec.ts
@@ -320,7 +320,7 @@ describe('connectSlot', () => {
     })
 
     describe('with two remote endpoints: A and B', () => {
-        describe('no event list sent by any endpoints', () => {
+        describe('no ignoredEvents list sent by any endpoints', () => {
             it('should wait for all remote endpoints to have signaled registration before sending the event', async () => {
                 const { channel: channelA, transport: transportA } =
                     makeTestTransport()
@@ -385,7 +385,7 @@ describe('connectSlot', () => {
             })
         })
 
-        describe('a blacklist is sent to one endpoint (A)', () => {
+        describe('an ignoredEvents list is sent to one endpoint (A)', () => {
             it('should NOT wait for remote endpoint A but SHOULD wait on remote endpoint B to have signaled registration before sending the event', async () => {
                 const { channel: channelA, transport: transportA } =
                     makeTestTransport()
@@ -397,10 +397,10 @@ describe('connectSlot', () => {
                     transportB,
                 ])
 
-                // Receiving a black list of events
+                // Receiving a list of events to ignore
                 channelA.fakeReceive({
                     type: 'event_list',
-                    blackList: ['broadcastBool'],
+                    ignoredEvents: ['broadcastBool'],
                 })
 
                 // This will be called only when B is ready we don't care about
@@ -429,10 +429,10 @@ describe('connectSlot', () => {
             })
         })
 
-        describe('an empty blacklist is sent to one endpoint (A)', () => {
+        describe('an empty ignoredEvents list is sent to one endpoint (A)', () => {
             // This is the same test as before. But this time the because the
-            // blackList is empty, we need to wait for A AND B to be registered
-            // to trigger the event
+            // ignoredEvents list is empty, we need to wait for A AND B to been
+            // registered to trigger the event.
             it('should wait for remote endpoint A and remote endpoint B to have signaled registration before sending the event', async () => {
                 const { channel: channelA, transport: transportA } =
                     makeTestTransport()
@@ -452,7 +452,7 @@ describe('connectSlot', () => {
 
                 channelA.fakeReceive({
                     type: 'event_list',
-                    blackList: [],
+                    ignoredEvents: [],
                 })
 
                 broadcastBool(true)


### PR DESCRIPTION
By design when an event bus has multiple remote endpoints, for an event to be triggered and sent through all channels, the handler of the slot needs to be registered on every transports. 
But sometimes there are events that we do not want to register on a specific channel. We have introduced the concept of "blackList"

```
const eventBus = createEventBus({ 
  events: Events, 
  channels: [listOfChannels], 
  blackList: [listOfEventKeysToBlackList] 
})
```

When the transport is created for the channels in the list, an `event_list` event will be triggered and send to the far end to signal that it does not need the slots in the list to be registered to trigger event for them.

under the hood, when a new event list is received on a transport, the slots of this events will be "registered" (fake the registration to release the triggers). And then handlers will be removed from the list of remote handlers.

