### PR TITLE
fix: handle attempt to send response when port is disconnected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-event-bus",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Distributed messaging in Typescript",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/test/Event.spec.ts
+++ b/test/Event.spec.ts
@@ -2,6 +2,7 @@ import { slot } from './../src/Slot'
 import { combineEvents, createEventBus } from './../src/Events'
 import { TestChannel } from './TestChannel'
 import { DEFAULT_PARAM } from './../src/Constants'
+import { flushPromises } from './testing-utils'
 
 describe('combineEvents()', () => {
 
@@ -93,7 +94,7 @@ describe('createEventBus()', () => {
             data: 5
         })
 
-        await Promise.resolve() // yied to ts-event-bus internals
+        await flushPromises()
         expect(channel.sendSpy).toHaveBeenCalledWith({
             type: 'response',
             slotName: 'numberToString',

--- a/test/Slot.spec.ts
+++ b/test/Slot.spec.ts
@@ -3,6 +3,7 @@ import { TestChannel } from './TestChannel'
 import { Transport } from './../src/Transport'
 import { DEFAULT_PARAM } from './../src/Constants'
 import { TransportRegistrationMessage } from './../src/Message'
+import { flushPromises } from './testing-utils'
 
 const makeTestTransport = () => {
     const channel = new TestChannel()
@@ -145,9 +146,7 @@ describe('connectSlot', () => {
                 type: 'handler_registered'
             })
 
-            // setTimeout(0) to yield control to ts-event-bus internals,
-            // so that the call to handlers can be processed
-            await new Promise(resolve => setTimeout(resolve, 0))
+            await flushPromises()
 
             // Once a remote handler is registered, both local and remote should be called
             expect(localCalled).toEqual(true)

--- a/test/TestChannel.ts
+++ b/test/TestChannel.ts
@@ -9,8 +9,18 @@ export class TestChannel extends GenericChannel {
 
     public autoReconnectSpy = jest.fn()
 
-    constructor() {
+    constructor(
+        options: { withAutoReconnect: boolean } = { withAutoReconnect: true }
+    ) {
         super()
+
+        if (options.withAutoReconnect) {
+            this.autoReconnect = () => {
+                this.callConnected()
+
+                this.autoReconnectSpy()
+            }
+        }
     }
 
     /**
@@ -39,11 +49,7 @@ export class TestChannel extends GenericChannel {
         this._error(new Error('LOLOL'))
     }
 
-    public autoReconnect() {
-        this.callConnected()
-
-        this.autoReconnectSpy()
-    }
+    public autoReconnect?: () => void | undefined
 
     public send(message: TransportMessage) {
         this.sendSpy(message)

--- a/test/Transport.spec.ts
+++ b/test/Transport.spec.ts
@@ -1,6 +1,7 @@
 import { Transport } from './../src/Transport'
 import { TransportMessage } from './../src/Message'
 import { TestChannel } from './TestChannel'
+import { flushPromises } from './testing-utils'
 
 const param = 'param'
 
@@ -89,7 +90,7 @@ describe('Transport', () => {
 
             channel.fakeReceive(request)
 
-            await Promise.resolve() // yield to ts-event-bus internals
+            await flushPromises()
             expect(handler).toHaveBeenCalledWith(request.data)
             expect(channel.sendSpy).toHaveBeenLastCalledWith({
                 slotName,
@@ -141,7 +142,7 @@ describe('Transport', () => {
                 }
             }
             channel.fakeReceive(request)
-            await Promise.resolve() // yield to ts-event-bus internals
+            await flushPromises()
             expect(handler).not.toHaveBeenCalled()
         })
 

--- a/test/Transport.spec.ts
+++ b/test/Transport.spec.ts
@@ -68,7 +68,6 @@ describe('Transport', () => {
             expect(channel.sendSpy).not.toHaveBeenCalledWith({ type: 'handler_unregistered', slotName, param })
         })
 
-
         it('should call the appropriate handler when a request is received', async () => {
 
             const slotName = 'buildCelery'
@@ -100,6 +99,86 @@ describe('Transport', () => {
                 data: {
                     color: 'blue'
                 }
+            })
+        })
+
+        describe('when the channel has autoReconnect capability', () => {
+            it('should call the handler when a request is received if the channel went disconnected', async () => {
+
+                const slotName = 'buildCelery'
+                const handler = slots[slotName][0]
+
+                // Register handler on slot
+                transport.registerHandler(slotName, param, handler)
+
+                const request: TransportMessage = {
+                    type: 'request',
+                    slotName,
+                    id: '5',
+                    param,
+                    data: {
+                        height: 5,
+                        constitution: 'strong'
+                    }
+                }
+
+                channel.callDisconnected()
+                channel.fakeReceive(request)
+
+                await flushPromises()
+                expect(handler).toHaveBeenCalledWith(request.data)
+                expect(channel.sendSpy).toHaveBeenCalledWith({
+                    slotName,
+                    type: 'response',
+                    id: '5',
+                    param,
+                    data: {
+                        color: 'blue'
+                    }
+                })
+            })
+        })
+
+        describe('when the channel does not have autoReconnect capability', () => {
+            beforeEach(() => {
+                channel = new TestChannel({ withAutoReconnect: false })
+                transport = new Transport(channel)
+                channel.callConnected()
+            })
+
+            it('should not call the handler when a request is received if the channel went disconnected', async () => {
+
+                const slotName = 'buildCelery'
+                const handler = slots[slotName][0]
+
+                // Register handler on slot
+                transport.registerHandler(slotName, param, handler)
+
+                const request: TransportMessage = {
+                    type: 'request',
+                    slotName,
+                    id: '5',
+                    param,
+                    data: {
+                        height: 5,
+                        constitution: 'strong'
+                    }
+                }
+
+                channel.fakeReceive(request)
+                channel.callDisconnected()
+
+                await flushPromises()
+                expect(handler).toHaveBeenCalledWith(request.data)
+                expect(channel.sendSpy).not.toHaveBeenCalledWith({
+                    slotName,
+                    type: 'response',
+                    id: '5',
+                    param,
+                    data: {
+                        color: 'blue'
+                    }
+                })
             })
         })
 

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Utility to flush current promises during a test when using fake timers
+ */
+export function flushPromises(): Promise<void> {
+    return new Promise(jest.requireActual('timers').setImmediate)
+}


### PR DESCRIPTION
Completes the "autoReconnect" feature by handling the response in case the channel went down (Disconnected) after receiving a message: if the channel has the autoReconnect capability we try to apply it. In any case if after trying the autoReconnect the channel is still Disconnected, we don't try to send the response.

I also added a  hacky `flushPromises` testing utility that allows running all internal promises.