### PR TITLE
chore: add deprecation warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Build Status](https://github.com/Dashlane/ts-event-bus/actions/workflows/nodejs.yml/badge.svg)](https://github.com/Dashlane/ts-event-bus/actions/workflows/nodejs.yml)
 [![Dependency Status](https://david-dm.org/Dashlane/ts-event-bus.svg)](https://david-dm.org/Dashlane/ts-event-bus)
 
+> [!CAUTION]
+> This package is no longer maintained. It is strongly advised against using it in any new project.
+
 Distributed messaging in Typescript
 
 `ts-event-bus` is a lightweight distributed messaging system. It allows several modules, potentially distributed over different runtime spaces to communicate through typed messages.


### PR DESCRIPTION
Adding a caution admonition in the main README file in order to warn for deprecation of the library.

See https://github.com/Dashlane/ts-event-bus/blob/1bfc015d53c677541dd6ce72715f0e803d5dcdb4/README.md for a preview.